### PR TITLE
Add multithreaded update loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A high-performance 2D game engine built with Python and Pygame, featuring multi-
 ### Multi-Core Processing
 - Automatic CPU core detection and utilization
 - Parallel entity processing for improved performance
-- Configurable thread count (defaults to 75% of available cores)
-- Efficient workload distribution
+- Configurable thread count (defaults to all available cores)
+- Efficient workload distribution using a thread pool
 
 ### Scene Management
 - Scene-based game organization


### PR DESCRIPTION
## Summary
- use a thread pool inside `BaseScene` to process entities in parallel
- document thread pool based multi-core processing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ba550c7083208714562b54301aef