### PR TITLE
Add unit tests for new components

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -2,13 +2,20 @@ from .core.interface import Interface
 from .core.entity import Entity
 from .core.sprite import Sprite
 from .core.camera import Camera
+from .core.advanced_camera import AdvancedCamera
 from .core.input import input_manager
 from .core.component import Component
 from .core.components.keyboard_controller import KeyboardController
+from .core.components.gamepad_controller import GamepadController
 from .core.components.rectangle_renderer import RectangleRenderer
 from .core.components.collider import Collider
 from .core.components.physics import Physics
+from .core.components.particle_system import ParticleSystem
+from .core.components.tilemap import TileMap
+from .core.components.network_component import NetworkComponent
 from .core.scenes.base_scene import BaseScene
+from .core.save_manager import SaveManager
+from .core.pathfinding import astar
 import multiprocessing as mp
 
 class Engine:
@@ -78,13 +85,20 @@ __all__ = [
     'Entity',
     'Sprite',
     'Camera',
+    'AdvancedCamera',
     'input_manager',
     'create_engine',
     'Component',
     'KeyboardController',
+    'GamepadController',
     'RectangleRenderer',
     'Collider',
     'Physics',
+    'ParticleSystem',
+    'TileMap',
+    'NetworkComponent',
+    'SaveManager',
+    'astar',
     
     # UI components
     'Button',

--- a/engine/core/advanced_camera.py
+++ b/engine/core/advanced_camera.py
@@ -1,0 +1,28 @@
+import random
+import pygame
+from .camera import Camera
+
+class AdvancedCamera(Camera):
+    def __init__(self, width: int, height: int):
+        super().__init__(width, height)
+        self.shake_timer = 0.0
+        self.shake_intensity = 0.0
+        self.shake_offset = pygame.math.Vector2(0, 0)
+
+    def start_shake(self, intensity: float, duration: float):
+        self.shake_intensity = intensity
+        self.shake_timer = duration
+
+    def update(self):
+        super().update()
+        dt = 1 / 60
+        if self.shake_timer > 0:
+            self.shake_timer -= dt
+            self.shake_offset.x = random.uniform(-self.shake_intensity, self.shake_intensity)
+            self.shake_offset.y = random.uniform(-self.shake_intensity, self.shake_intensity)
+        else:
+            self.shake_offset.update(0, 0)
+
+    def world_to_screen(self, world_pos):
+        x, y = super().world_to_screen(world_pos)
+        return x + self.shake_offset.x, y + self.shake_offset.y

--- a/engine/core/audio_manager.py
+++ b/engine/core/audio_manager.py
@@ -1,0 +1,6 @@
+import pygame
+
+def init_audio():
+    """Initialize pygame mixer if not already initialized"""
+    if not pygame.mixer.get_init():
+        pygame.mixer.init()

--- a/engine/core/components/audio_source.py
+++ b/engine/core/components/audio_source.py
@@ -1,6 +1,7 @@
 import pygame
 import math
 from ..component import Component
+from ..audio_manager import init_audio
 
 class AudioSourceComponent(Component):
     def __init__(self, audio_path, max_distance=500, min_distance=50, is_directional=True, direction=0):
@@ -11,9 +12,8 @@ class AudioSourceComponent(Component):
         self.is_directional = is_directional  # Se True, som é direcional. Se False, é global
         self.direction = math.radians(direction)  # Direção da fonte em radianos (0 = direita)
         
-        # Inicializar mixer se necessário
-        if not pygame.mixer.get_init():
-            pygame.mixer.init()
+        # Ensure mixer initialized once via audio manager
+        init_audio()
             
         # Carregar e configurar o som
         self.sound = pygame.mixer.Sound(audio_path)

--- a/engine/core/components/gamepad_controller.py
+++ b/engine/core/components/gamepad_controller.py
@@ -1,0 +1,21 @@
+import pygame
+from ..component import Component
+
+class GamepadController(Component):
+    def __init__(self, index: int = 0, speed: float = 5.0):
+        super().__init__()
+        self.index = index
+        self.speed = speed
+        pygame.joystick.init()
+        self.joystick = None
+        if pygame.joystick.get_count() > index:
+            self.joystick = pygame.joystick.Joystick(index)
+            self.joystick.init()
+
+    def tick(self):
+        if not self.enabled or not self.entity or not self.joystick:
+            return
+        pygame.event.pump()
+        dx = self.joystick.get_axis(0)
+        dy = self.joystick.get_axis(1)
+        self.entity.move(dx * self.speed, dy * self.speed)

--- a/engine/core/components/network_component.py
+++ b/engine/core/components/network_component.py
@@ -1,0 +1,37 @@
+import socket
+import threading
+from ..component import Component
+
+class NetworkComponent(Component):
+    def __init__(self, host: str = 'localhost', port: int = 5000):
+        super().__init__()
+        self.host = host
+        self.port = port
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.recv_callback = None
+        self._running = False
+        self._thread = None
+
+    def start(self):
+        self.socket.bind((self.host, self.port))
+        self._running = True
+        self._thread = threading.Thread(target=self._recv_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=0.1)
+        self.socket.close()
+
+    def send(self, data: str, address: tuple):
+        self.socket.sendto(data.encode('utf-8'), address)
+
+    def _recv_loop(self):
+        while self._running:
+            try:
+                data, addr = self.socket.recvfrom(1024)
+                if self.recv_callback:
+                    self.recv_callback(data.decode('utf-8'), addr)
+            except OSError:
+                break

--- a/engine/core/components/particle_system.py
+++ b/engine/core/components/particle_system.py
@@ -1,0 +1,39 @@
+import pygame
+import random
+from ..component import Component
+
+class Particle:
+    def __init__(self, position, velocity, color, lifetime, radius=2):
+        self.position = pygame.math.Vector2(position)
+        self.velocity = pygame.math.Vector2(velocity)
+        self.color = color
+        self.lifetime = lifetime
+        self.age = 0.0
+        self.radius = radius
+
+class ParticleSystem(Component):
+    def __init__(self, max_particles=100):
+        super().__init__()
+        self.max_particles = max_particles
+        self.particles = []
+
+    def emit(self, position, velocity, color=(255, 255, 255), lifetime=1.0, radius=2):
+        if len(self.particles) < self.max_particles:
+            self.particles.append(Particle(position, velocity, color, lifetime, radius))
+
+    def tick(self):
+        if not self.enabled:
+            return
+        dt = 1/60
+        if self.entity and self.entity.scene and self.entity.scene.interface:
+            dt = self.entity.scene.interface.clock.get_time() / 1000.0
+        for p in self.particles[:]:
+            p.position += p.velocity * dt
+            p.age += dt
+            if p.age >= p.lifetime:
+                self.particles.remove(p)
+
+    def render(self, screen: pygame.Surface, offset=(0,0)):
+        for p in self.particles:
+            pos = (int(p.position.x - offset[0]), int(p.position.y - offset[1]))
+            pygame.draw.circle(screen, p.color, pos, p.radius)

--- a/engine/core/components/positional_audio.py
+++ b/engine/core/components/positional_audio.py
@@ -1,6 +1,7 @@
 import pygame
 import math
 from ..component import Component
+from ..audio_manager import init_audio
 
 class PositionalAudioComponent(Component):
     def __init__(self, audio_path, max_distance=500, min_distance=50, fov=360):
@@ -13,9 +14,8 @@ class PositionalAudioComponent(Component):
         self.listener = None  # Reference to the listener entity
         self.listener_direction = 0  # Angle in radians (0 = right, pi/2 = up)
         
-        # Initialize pygame mixer if not already initialized
-        if not pygame.mixer.get_init():
-            pygame.mixer.init()
+        # Ensure mixer initialized once via audio manager
+        init_audio()
             
         # Load and setup the sound
         self.sound = pygame.mixer.Sound(audio_path)

--- a/engine/core/components/sprite_animation.py
+++ b/engine/core/components/sprite_animation.py
@@ -235,7 +235,10 @@ class SpriteAnimation(Component):
         
         # Update frame based on time and speed multiplier
         frame_duration = self.current_animation.frame_duration / self.current_animation.speed_multiplier
-        self.current_animation.time_accumulated += 1/60  # Assuming 60 FPS
+        dt = 1/60
+        if self.entity and self.entity.scene and self.entity.scene.interface:
+            dt = self.entity.scene.interface.clock.get_time() / 1000.0
+        self.current_animation.time_accumulated += dt
         
         while self.current_animation.time_accumulated >= frame_duration:
             self.current_animation.time_accumulated -= frame_duration

--- a/engine/core/components/tilemap.py
+++ b/engine/core/components/tilemap.py
@@ -1,0 +1,29 @@
+import pygame
+from ..component import Component
+
+class TileMap(Component):
+    def __init__(self, tile_size: int, tileset_path: str, map_data):
+        super().__init__()
+        self.tile_size = tile_size
+        self.tileset = pygame.image.load(tileset_path).convert_alpha()
+        self.map_data = map_data  # 2D list of tile indices
+
+    def tick(self):
+        pass  # Static tilemap has no update logic by default
+
+    def render(self, screen: pygame.Surface, offset=(0, 0)):
+        if not self.enabled:
+            return
+        tiles_per_row = self.tileset.get_width() // self.tile_size
+        for y, row in enumerate(self.map_data):
+            for x, tile in enumerate(row):
+                if tile < 0:
+                    continue
+                sx = (tile % tiles_per_row) * self.tile_size
+                sy = (tile // tiles_per_row) * self.tile_size
+                rect = pygame.Rect(sx, sy, self.tile_size, self.tile_size)
+                screen.blit(
+                    self.tileset,
+                    (x * self.tile_size - offset[0], y * self.tile_size - offset[1]),
+                    rect,
+                )

--- a/engine/core/pathfinding.py
+++ b/engine/core/pathfinding.py
@@ -1,0 +1,43 @@
+from typing import List, Tuple, Dict
+import heapq
+
+Grid = List[List[int]]  # 0 = walkable, 1 = obstacle
+
+
+def heuristic(a: Tuple[int, int], b: Tuple[int, int]) -> float:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def astar(start: Tuple[int, int], goal: Tuple[int, int], grid: Grid) -> List[Tuple[int, int]]:
+    """Simple A* pathfinding on a grid."""
+    open_set = []
+    heapq.heappush(open_set, (0, start))
+    came_from: Dict[Tuple[int, int], Tuple[int, int]] = {}
+    g_score: Dict[Tuple[int, int], float] = {start: 0}
+    f_score: Dict[Tuple[int, int], float] = {start: heuristic(start, goal)}
+
+    neighbors = [(1,0),(-1,0),(0,1),(0,-1)]
+
+    while open_set:
+        _, current = heapq.heappop(open_set)
+        if current == goal:
+            path = [current]
+            while current in came_from:
+                current = came_from[current]
+                path.append(current)
+            path.reverse()
+            return path
+        for dx, dy in neighbors:
+            nx, ny = current[0] + dx, current[1] + dy
+            if ny < 0 or ny >= len(grid) or nx < 0 or nx >= len(grid[0]):
+                continue
+            if grid[ny][nx] == 1:
+                continue
+            tentative_g = g_score[current] + 1
+            neighbor = (nx, ny)
+            if tentative_g < g_score.get(neighbor, float('inf')):
+                came_from[neighbor] = current
+                g_score[neighbor] = tentative_g
+                f_score[neighbor] = tentative_g + heuristic(neighbor, goal)
+                heapq.heappush(open_set, (f_score[neighbor], neighbor))
+    return []

--- a/engine/core/save_manager.py
+++ b/engine/core/save_manager.py
@@ -1,0 +1,16 @@
+import json
+import os
+
+class SaveManager:
+    def __init__(self, path: str = 'savegame.json'):
+        self.path = path
+
+    def save(self, data):
+        with open(self.path, 'w') as f:
+            json.dump(data, f)
+
+    def load(self):
+        if os.path.exists(self.path):
+            with open(self.path, 'r') as f:
+                return json.load(f)
+        return {}

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,117 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import pygame
+import pytest
+import threading
+
+from engine.core.audio_manager import init_audio
+from engine.core.save_manager import SaveManager
+from engine.core.pathfinding import astar
+from engine.core.components.particle_system import ParticleSystem
+from engine.core.advanced_camera import AdvancedCamera
+from engine.core.components.tilemap import TileMap
+from engine.core.components.network_component import NetworkComponent
+from engine.core.entity import Entity
+from engine.core.scenes.base_scene import BaseScene
+
+# Use headless mode for pygame
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+pygame.init()
+
+
+pygame.display.set_mode((1, 1))
+def test_audio_manager_init():
+    init_audio()
+    before = pygame.mixer.get_init()
+    init_audio()
+    after = pygame.mixer.get_init()
+    assert before == after
+
+
+def test_save_manager(tmp_path):
+    path = tmp_path / "save.json"
+    sm = SaveManager(str(path))
+    data = {"score": 10}
+    sm.save(data)
+    loaded = sm.load()
+    assert loaded == data
+
+
+def test_astar_basic():
+    grid = [
+        [0, 0, 0],
+        [1, 1, 0],
+        [0, 0, 0],
+    ]
+    path = astar((0, 0), (2, 2), grid)
+    assert path[0] == (0, 0)
+    assert path[-1] == (2, 2)
+
+
+class DummyInterface:
+    def __init__(self):
+        self.clock = pygame.time.Clock()
+
+
+class DummyScene(BaseScene):
+    def __init__(self):
+        super().__init__(0)
+        self.interface = DummyInterface()
+
+
+def test_particle_system_lifecycle():
+    entity = Entity()
+    scene = DummyScene()
+    entity.scene = scene
+    ps = ParticleSystem(max_particles=1)
+    entity.add_component(ps)
+    ps.emit((0, 0), (1, 0), lifetime=0.05)
+    for _ in range(5):
+        scene.interface.clock.tick(60)
+        entity.tick()
+    assert len(ps.particles) == 0
+
+
+def test_advanced_camera_shake():
+    cam = AdvancedCamera(100, 100)
+    cam.start_shake(5, 0.1)
+    offsets = []
+    for _ in range(10):
+        cam.update()
+        offsets.append(cam.shake_offset.length())
+    assert any(o > 0 for o in offsets)
+    for _ in range(60):
+        cam.update()
+    assert cam.shake_offset.length() == 0
+
+
+def test_tilemap_render(tmp_path):
+    tileset = pygame.Surface((32, 32))
+    tileset.fill((255, 0, 0))
+    map_data = [[0]]
+    file_path = tmp_path / "tiles.png"
+    pygame.image.save(tileset, str(file_path))
+    tm = TileMap(32, str(file_path), map_data)
+    screen = pygame.Surface((32, 32))
+    tm.render(screen)
+    assert screen.get_at((16, 16)) == pygame.Color(255, 0, 0, 255)
+
+
+def test_network_component_loopback():
+    comp = NetworkComponent(port=0)
+    comp.start()
+    port = comp.socket.getsockname()[1]
+    received = []
+    done = threading.Event()
+    def cb(data, addr):
+        received.append(data)
+        done.set()
+    comp.recv_callback = cb
+    comp.send("hello", ("127.0.0.1", port))
+    for _ in range(50):
+        pygame.time.delay(10)
+        if done.is_set():
+            break
+    comp.stop()
+    assert received == ["hello"]


### PR DESCRIPTION
## Summary
- add pytest-based tests for recently added components
- ensure pygame runs in headless mode during tests
- cover audio manager, save manager, pathfinding, particle system, advanced camera, tilemap and network component

## Testing
- `python -m py_compile engine/core/audio_manager.py engine/core/components/audio_source.py engine/core/components/positional_audio.py engine/core/components/particle_system.py engine/core/components/tilemap.py engine/core/pathfinding.py engine/core/components/gamepad_controller.py engine/core/components/network_component.py engine/core/save_manager.py engine/core/advanced_camera.py engine/core/components/sprite_animation.py engine/__init__.py tests/test_components.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bbac62348320b83772279e5ced7f