### PR TITLE
Add liquid simulator demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,3 +296,27 @@ def main():
     engine.set_scene("game", PuzzleScene())
     engine.run()
 ```
+### 4. Liquid Simulator Demo
+```python
+import pygame
+from engine.core.scenes.scene_manager import SceneManager
+from scenes.liquid_demo_scene import LiquidDemoScene
+
+pygame.init()
+screen = pygame.display.set_mode((800, 600))
+manager = SceneManager()
+manager.add_scene("liquid", LiquidDemoScene())
+manager.set_scene("liquid", transition=False)
+clock = pygame.time.Clock()
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+        manager.handle_event(event)
+    manager.update()
+    screen.fill((0, 0, 0))
+    manager.render(screen)
+    pygame.display.flip()
+    clock.tick(60)
+```

--- a/liquid_demo_main.py
+++ b/liquid_demo_main.py
@@ -1,0 +1,35 @@
+import pygame
+from engine.core.scenes.scene_manager import SceneManager
+from scenes.liquid_demo_scene import LiquidDemoScene
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600))
+    pygame.display.set_caption("Liquid Simulator Demo")
+
+    scene_manager = SceneManager()
+    scene_manager.add_scene("liquid", LiquidDemoScene())
+    scene_manager.set_scene("liquid", transition=False)
+
+    clock = pygame.time.Clock()
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                running = False
+            scene_manager.handle_event(event)
+
+        scene_manager.update()
+        screen.fill((0, 0, 0))
+        scene_manager.render(screen)
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/scenes/liquid_demo_scene.py
+++ b/scenes/liquid_demo_scene.py
@@ -1,0 +1,56 @@
+import pygame
+from engine.core.scenes.base_scene import BaseScene
+
+class LiquidDemoScene(BaseScene):
+    def __init__(self, width=200, height=150, scale=4):
+        super().__init__()
+        self.grid_width = width
+        self.grid_height = height
+        self.scale = scale
+        self.damping = 0.99
+        # Height buffers
+        self.current = [[0.0 for _ in range(height)] for _ in range(width)]
+        self.previous = [[0.0 for _ in range(height)] for _ in range(width)]
+        self.surface = pygame.Surface((width, height))
+
+    def disturb(self, x, y, magnitude=100.0):
+        if 1 <= x < self.grid_width-1 and 1 <= y < self.grid_height-1:
+            self.previous[x][y] = magnitude
+
+    def handle_event(self, event):
+        super().handle_event(event)
+        if event.type == pygame.MOUSEBUTTONDOWN:
+            gx = event.pos[0] // self.scale
+            gy = event.pos[1] // self.scale
+            self.disturb(gx, gy)
+
+    def update(self):
+        super().update()
+        if not self._is_loaded:
+            return
+        for x in range(1, self.grid_width-1):
+            for y in range(1, self.grid_height-1):
+                val = (
+                    self.previous[x-1][y] +
+                    self.previous[x+1][y] +
+                    self.previous[x][y-1] +
+                    self.previous[x][y+1]
+                ) / 2 - self.current[x][y]
+                val *= self.damping
+                self.current[x][y] = val
+        # Swap buffers
+        self.current, self.previous = self.previous, self.current
+
+        # Update surface pixels
+        for x in range(self.grid_width):
+            for y in range(self.grid_height):
+                c = 127 + int(self.current[x][y])
+                c = max(0, min(255, c))
+                self.surface.set_at((x, y), (0, 0, c))
+
+    def render(self, screen: pygame.Surface):
+        scaled = pygame.transform.scale(
+            self.surface,
+            (self.grid_width * self.scale, self.grid_height * self.scale)
+        )
+        screen.blit(scaled, (0, 0))


### PR DESCRIPTION
## Summary
- add a new LiquidDemoScene for simple fluid ripples
- add launcher script `liquid_demo_main.py`
- document the demo in README

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d33d841083209cb6e07e683b5585