### PR TITLE
Fix water particle demo interface setup

### DIFF
--- a/water_particle_demo_main.py
+++ b/water_particle_demo_main.py
@@ -1,4 +1,5 @@
 import pygame
+from engine.core.interface import Interface
 from engine.core.scenes.scene_manager import SceneManager
 from scenes.water_particle_scene import WaterParticleScene
 
@@ -8,7 +9,10 @@ def main():
     screen = pygame.display.set_mode((800, 600))
     pygame.display.set_caption("Water Particle Demo")
 
+    interface = Interface(screen)
+
     scene_manager = SceneManager()
+    scene_manager.set_interface(interface)
     scene_manager.add_scene("water", WaterParticleScene())
     scene_manager.set_scene("water", transition=False)
 


### PR DESCRIPTION
## Summary
- initialize the scene manager with an Interface in the water particle demo so scenes have a valid clock

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d62a518c8320b31590b89b177589