### PR TITLE
Fix missing List import in Entity

### DIFF
--- a/engine/core/entity.py
+++ b/engine/core/entity.py
@@ -1,5 +1,5 @@
 import pygame
-from typing import Dict, Type, Optional, Any, Tuple, TypeVar
+from typing import Dict, Type, Optional, Any, Tuple, TypeVar, List
 
 from engine.core.component import Component
 


### PR DESCRIPTION
## Summary
- add List import for render method annotation

## Testing
- `pytest -q` *(fails: Missing mocks for pygame objects and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a111883e48320af3a9407506c1bd5